### PR TITLE
add default_acl option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module "gcs_bucket" {
 | project\_id | The ID of the google project to which the resource belongs. If it is not provided, the provider project is used. | string | `` | no |
 | region | The GCS region. If it is not provided, the provider region is used. | string | `` | no |
 | role\_entities | - | list | `<list>` | no |
+| default\_acl | Set the established ACL as default for all objects in the bucket. | string | false | no |
 | storage\_class | The Storage Class of the new bucket. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE. | string | `REGIONAL` | no |
 | versioning | Version bucket objects? | string | `false` | no |
 | website\_config | - | list | `<list>` | no |

--- a/acl.tf
+++ b/acl.tf
@@ -30,7 +30,7 @@ locals {
 resource "google_storage_bucket_acl" "default_bucket" {
   bucket = "${google_storage_bucket.default.name}"
   role_entity = ["${concat(local.default_role_entities, var.role_entities)}"]
-
+  default_acl = "${var.default_acl}"
 }
 resource "google_storage_bucket_acl" "logging_bucket" {
   bucket = "${google_storage_bucket.logging.name}"

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,13 @@ variable "role_entities" {
   type    = "list"
 }
 
+variable "default_acl" {
+  description = "Set the established ACL as default for all objects in the bucket."
+  default = false
+  type = "string"
+}
+
+
 variable "storage_class" {
   description = "The Storage Class of the new bucket. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE."
   default     = "REGIONAL"


### PR DESCRIPTION
I added the option to apply the created `google_storage_bucket_acl` as the default one for the bucket.

For instance it allows for public buckets to have `READER:allUsers` correctly applied to the objects being added or uploaded to bucket automatically.

